### PR TITLE
Update ruboty/slak_rtm version to fix bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,32 +24,33 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.0)
+    activesupport (6.0.3.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     akismet (2.0.0)
     buftok (0.2.0)
     chrono (0.4.0)
       activesupport
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.6)
     declarative (0.0.10)
     declarative-option (0.1.0)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.4.0)
+    dotenv (2.7.5)
     elo_rating (1.0.0)
     equalizer (0.0.11)
     event_emitter (0.2.6)
     eventmachine (1.2.7)
-    faraday (0.15.1)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.1)
       faraday (>= 0.7.4, < 1.0)
-    faye-websocket (0.10.7)
+    faye-websocket (0.10.9)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     google-api-client (0.19.0)
@@ -78,7 +79,7 @@ GEM
     http-form_data (2.0.0)
     http_parser.rb (0.6.0)
     httpclient (2.8.3)
-    i18n (1.0.1)
+    i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     increments-schedule (0.17.0)
       holiday_japan (~> 1.1)
@@ -94,9 +95,9 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    minitest (5.11.3)
-    multi_json (1.12.2)
-    multipart-post (2.0.0)
+    minitest (5.14.1)
+    multi_json (1.14.1)
+    multipart-post (2.1.1)
     naught (1.1.0)
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -170,7 +171,7 @@ GEM
       ruboty (~> 1.0)
     ruboty-scorekeeper (0.0.3)
       ruboty
-    ruboty-slack_rtm (3.1.0)
+    ruboty-slack_rtm (3.2.1)
       faraday (~> 0.11)
       ruboty (>= 1.1.4)
       slack-api (~> 1.6)
@@ -206,19 +207,20 @@ GEM
       multipart-post (~> 2.0)
       naught (~> 1.0)
       simple_oauth (~> 0.3.0)
-    tzinfo (1.2.5)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uber (0.1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
-    websocket (1.2.5)
+    websocket (1.2.8)
     websocket-client-simple (0.3.0)
       event_emitter
       websocket
-    websocket-driver (0.7.0)
+    websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
@@ -250,4 +252,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
## What
- ruboty/slack_rtmのバージョンアップを行なった

## Why
- Qiitanが度々シャットダウンしていた理由は、slack_rtmのバグが原因であり、このバグの修正が最新のバージョンによって行われていた。よってバージョンアップを行うことによって 24時間Qiitanが稼働するようにする
