### PR TITLE
Update increments-schedule 0.17.0->0.18.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,4 +30,4 @@ gem "ruboty-alias", "= 0.0.8"
 gem "ruboty-cron", "~> 1.1.0"
 gem "ruboty-qiita-github", github: 'increments/ruboty-qiita-github'
 gem "ruboty-ruby_persistence", "= 0.2.0"
-gem "increments-schedule", "~> 0.17.0"
+gem "increments-schedule", "~> 0.18.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
-    holiday_japan (1.4.2)
+    holiday_japan (1.4.4)
     http (3.0.0)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -81,7 +81,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
-    increments-schedule (0.17.0)
+    increments-schedule (0.18.0)
       holiday_japan (~> 1.1)
     jwt (2.1.0)
     little-plugger (1.1.4)
@@ -226,7 +226,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  increments-schedule (~> 0.17.0)
+  increments-schedule (~> 0.18.0)
   rake (< 11.0.0)
   ruboty-alias (= 0.0.8)
   ruboty-bundler
@@ -252,4 +252,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.1.4
+   2.2.15


### PR DESCRIPTION
変更点はこちら参照
https://github.com/increments/increments-schedule/pull/5
https://github.com/increments/increments-schedule/pull/6

具体的な変更は給料日を15日にしただけだが、対応したRubyバージョンの変更やRspecの修正、travis-ciの環境の修正もしている。