### PR TITLE
Fix OpenSSL::SSL::SSLError: SSL_write error / SNI support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+vendor/bundle
+.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -31,3 +31,5 @@ gem "ruboty-cron", "~> 1.1.0"
 gem "ruboty-qiita-github", github: 'increments/ruboty-qiita-github'
 gem "ruboty-ruby_persistence", "= 0.2.0"
 gem "increments-schedule", "~> 0.18.0"
+
+gem 'websocket-client-simple', github: 'fuyuton/websocket-client-simple'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/fuyuton/websocket-client-simple.git
+  revision: 3f455717022bc17bd079ab7cf54252dc120e5059
+  specs:
+    websocket-client-simple (0.3.3)
+      event_emitter (~> 0.2.6)
+      websocket (~> 1.2.8)
+
+GIT
   remote: https://github.com/increments/ruboty-qiita-github.git
   revision: 20943ca1e3934884b7d9736530565058293f1a7f
   specs:
@@ -213,10 +221,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
-    websocket (1.2.8)
-    websocket-client-simple (0.3.0)
-      event_emitter
-      websocket
+    websocket (1.2.9)
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -247,6 +252,7 @@ DEPENDENCIES
   ruboty-slack_rtm
   ruboty-sushiyuki
   ruboty-twitter_search
+  websocket-client-simple!
 
 RUBY VERSION
    ruby 2.6.3p62


### PR DESCRIPTION
## What

The WebSocket connection method has been changed due to Slack's specification change.

> November 2021
> If you still use rtm.connect or rtm.start to connect to Slack, you'll notice that all WebSocket URLs now begin with wss://wss-primary.slack.com.
> As previously announced, apps & integrations created after today, November 30, 2021, must use rtm.connect instead of the deprecated rtm.start when connecting to the RTM API. Learn more about this and what's next for existing users of rtm.start.
> https://api.slack.com/changelog
> https://api.slack.com/changelog/2021-10-rtm-start-to-stop

A pull request has been created on the library side, but it hasn't been merged yet.

Refer to the forked repository and attempt to recover.

## Ref

- https://github.com/rosylilly/ruboty-slack_rtm/issues/46
- https://github.com/shokai/websocket-client-simple/pull/36