### PR TITLE
Bump ruboty-slack_rtm from 3.2.4 to 3.2.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
       ruboty (~> 1.0)
     ruboty-scorekeeper (0.0.3)
       ruboty
-    ruboty-slack_rtm (3.2.4)
+    ruboty-slack_rtm (3.2.5)
       faraday (~> 0.11)
       ruboty (>= 1.1.4)
       slack-api (~> 1.6)


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->

This change includes https://github.com/rosylilly/ruboty-slack_rtm/pull/48.

FIx error FrozenError: can't modify frozen String: "" when you register a job as follows.

if "00 15 * * *" @qiitan ruby "hoge" if Increments::Schedule.work_day?
This job return nil when without work day.
nil.to_s returns frozen string when ruby version is 2.7 or higher.
The error is caused by the combination of these two factors, and the ruboty-slack_rtm is correcting the behavior when it receives nil.