### PR TITLE
Add qiita-rb gem to use qiita api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem 'qiita'
 gem "rake", "< 13.0.0"
 gem "ruboty-replace"
 gem "ruboty-bundler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,10 +56,21 @@ GEM
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     public_suffix (3.0.1)
+    qiita (1.3.5)
+      activesupport
+      faraday (~> 0.9)
+      faraday_middleware
+      rack
+      rainbow
+      rouge
+      slop (< 4.0.0)
+    rack (3.0.7)
+    rainbow (3.1.1)
     rake (12.3.3)
     redis (4.0.1)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
+    rouge (4.1.0)
     ruboty (1.3.1)
       activesupport
       bundler
@@ -135,6 +146,7 @@ PLATFORMS
 
 DEPENDENCIES
   increments-schedule (~> 0.18.0)
+  qiita
   rake (< 13.0.0)
   ruboty-alias (= 0.0.8)
   ruboty-bundler


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->

Added https://github.com/increments/qiita-rb gem to use Qiita API.
It seems that when we deleted ruboty-qiita_police gem, we deleted qiita-rb gem along with it.