### PR TITLE
Bump up ruboty-openai_chat to 0.4.0 (from 0.3.1)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       activesupport
       octokit
       ruboty
-    ruboty-openai_chat (0.3.1)
+    ruboty-openai_chat (0.4.0)
       ruboty
       ruby-openai (~> 3.5)
     ruboty-qiita-github (0.3.2)


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->

This PR bumps up [ruboty-openai_chat](https://github.com/tomoasleep/ruboty-openai_chat) to 0.4.0

The version has the following changes:

* https://github.com/tomoasleep/ruboty-openai_chat/pull/2
