### PR TITLE
Remove old faraday

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "ruboty-echo"
 gem "ruboty-irasutoya", github: "june29/ruboty-irasutoya"
 gem "ruboty-redis"
 gem "ruboty-scorekeeper"
-gem "ruboty-slack_rtm"
+gem "ruboty-slack_rtm", github: "atm-snag2/ruboty-slack_rtm", branch: 'use-slack-ruby-client'
 gem "ruboty-rating"
 gem "ruboty-response", github: 'increments/ruboty-response'
 gem "ruboty-ruby", ">= 0.0.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,8 +39,8 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     base64 (0.2.0)
     bigdecimal (3.1.7)
-    chrono (0.4.0)
-      activesupport
+    chrono (0.6.0)
+      activesupport (>= 5.2)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     dotenv (2.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/atm-snag2/ruboty-slack_rtm.git
+  revision: 860fe68c3dde22e439b4e44d723306befa244e19
+  branch: use-slack-ruby-client
+  specs:
+    ruboty-slack_rtm (3.2.5)
+      ruboty (>= 1.1.4)
+      slack-ruby-client (~> 2.0)
+      websocket-client-simple (>= 0.5.0)
+
+GIT
   remote: https://github.com/increments/ruboty-response.git
   revision: 2255896972ddc9e1e549333b74e9a5724a7decdf
   specs:
@@ -15,60 +25,73 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.6.1)
+    activesupport (7.1.3.2)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.7)
     chrono (0.4.0)
       activesupport
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
     dotenv (2.8.1)
+    drb (2.2.1)
     elo_rating (1.0.0)
     event_emitter (0.2.6)
-    eventmachine (1.2.7)
-    faraday (0.17.3)
-      multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.1)
-      faraday (>= 0.7.4, < 1.0)
-    faye-websocket (0.10.9)
-      eventmachine (>= 0.12.0)
-      websocket-driver (>= 0.5.1)
+    faraday (2.8.1)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-mashify (0.1.1)
+      faraday (~> 2.0)
+      hashie
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
+    faraday-net_http (3.0.2)
+    gli (2.21.1)
+    hashie (5.0.0)
     holiday_japan (1.4.4)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.12.0)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     increments-schedule (0.18.0)
       holiday_japan (~> 1.1)
     mem (0.1.5)
     mini_mime (1.1.5)
-    minitest (5.16.3)
-    multi_json (1.14.1)
+    minitest (5.22.3)
     multi_xml (0.6.0)
-    multipart-post (2.1.1)
-    octokit (4.8.0)
-      sawyer (~> 0.8.0, >= 0.5.3)
-    public_suffix (3.0.1)
-    qiita (1.3.5)
+    multipart-post (2.4.0)
+    mutex_m (0.2.0)
+    octokit (8.1.0)
+      base64
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
+    public_suffix (5.0.4)
+    qiita (1.5.0)
       activesupport
-      faraday (~> 0.9)
-      faraday_middleware
+      faraday (>= 2, < 3)
       rack
       rainbow
       rouge
       slop (< 4.0.0)
-    rack (3.0.7)
+    rack (3.0.9.1)
     rainbow (3.1.1)
     rake (12.3.3)
     redis (4.0.1)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
-    rouge (4.1.0)
+    rouge (4.2.0)
     ruboty (1.3.1)
       activesupport
       bundler
@@ -111,33 +134,26 @@ GEM
       ruboty (~> 1.0)
     ruboty-scorekeeper (0.0.3)
       ruboty
-    ruboty-slack_rtm (3.2.5)
-      faraday (~> 0.11)
-      ruboty (>= 1.1.4)
-      slack-api (~> 1.6)
-      websocket-client-simple (>= 0.5.0)
     ruboty-sushiyuki (0.0.2)
     ruby-openai (3.5.0)
       httparty (>= 0.18.1)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
-    slack-api (1.6.1)
-      faraday (~> 0.11)
-      faraday_middleware (~> 0.10.0)
-      faye-websocket (~> 0.10.6)
-      multi_json (~> 1.0, >= 1.0.3)
+    ruby2_keywords (0.0.5)
+    sawyer (0.9.2)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
+    slack-ruby-client (2.3.0)
+      faraday (>= 2.0)
+      faraday-mashify
+      faraday-multipart
+      gli
+      hashie
     slop (3.6.0)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    websocket (1.2.9)
-    websocket-client-simple (0.6.0)
+    websocket (1.2.10)
+    websocket-client-simple (0.8.0)
       event_emitter
       websocket
-    websocket-driver (0.7.2)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
-    zeitwerk (2.6.0)
 
 PLATFORMS
   ruby
@@ -160,7 +176,7 @@ DEPENDENCIES
   ruboty-ruby (>= 0.0.2)
   ruboty-ruby_persistence (= 0.2.0)
   ruboty-scorekeeper
-  ruboty-slack_rtm
+  ruboty-slack_rtm!
   ruboty-sushiyuki
 
 RUBY VERSION


### PR DESCRIPTION
## What

- Remove old faraday
    - use patched ruboty-slack_rtm
    - bump qiita, octokit
    - and
        - bump chrono for activesupport 7.1

<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
