### PR TITLE
Use forked ruboty-redis for verify none

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "ruboty-replace"
 gem "ruboty-bundler"
 gem "ruboty-echo"
 gem "ruboty-irasutoya", github: "june29/ruboty-irasutoya"
-gem "ruboty-redis"
+gem "ruboty-redis", github: "Umekawa/ruboty-redis", branch: 'master'
 gem "ruboty-scorekeeper"
 gem "ruboty-slack_rtm", github: "atm-snag2/ruboty-slack_rtm", branch: 'use-slack-ruby-client'
 gem "ruboty-rating"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/Umekawa/ruboty-redis.git
+  revision: 103d8554adb74e3b6ab891c34706b4a003024044
+  branch: master
+  specs:
+    ruboty-redis (0.0.6)
+      redis
+      redis-namespace
+      ruboty
+
+GIT
   remote: https://github.com/atm-snag2/ruboty-slack_rtm.git
   revision: 821035500115acc02a52711d7c386fdbc447488e
   branch: use-slack-ruby-client
@@ -88,9 +98,12 @@ GEM
     rack (3.0.9.1)
     rainbow (3.1.1)
     rake (13.2.1)
-    redis (4.0.1)
-    redis-namespace (1.6.0)
-      redis (>= 3.0.4)
+    redis (5.3.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.22.2)
+      connection_pool
+    redis-namespace (1.11.0)
+      redis (>= 4)
     rouge (4.2.0)
     ruboty (1.3.1)
       activesupport
@@ -122,10 +135,6 @@ GEM
       ruboty
     ruboty-rating (0.1.1)
       elo_rating (~> 1.0)
-    ruboty-redis (0.0.6)
-      redis
-      redis-namespace
-      ruboty
     ruboty-replace (0.0.1)
       ruboty
     ruboty-ruby (0.0.2)
@@ -170,7 +179,7 @@ DEPENDENCIES
   ruboty-openai_chat (~> 0.3)
   ruboty-qiita-github
   ruboty-rating
-  ruboty-redis
+  ruboty-redis!
   ruboty-replace
   ruboty-response!
   ruboty-ruby (>= 0.0.2)


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
- Change ruboty-redis by forked
    - need verify-none option for use in heroku
    - [Heroku Data for Redis への接続 | Heroku Dev Center](https://devcenter.heroku.com/ja/articles/connecting-heroku-redis#connecting-in-rails)