### PR TITLE
Use ruboty-slack_events instead of ruboty-slack_rtm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "ruboty-bundler"
 gem "ruboty-echo"
 gem "ruboty-redis", github: "Umekawa/ruboty-redis", branch: 'master'
 gem "ruboty-scorekeeper"
-gem "ruboty-slack_rtm", github: "atm-snag2/ruboty-slack_rtm", branch: 'use-slack-ruby-client'
+gem "ruboty-slack_events"
 gem "ruboty-response", github: 'increments/ruboty-response'
 gem "ruboty-ruby", ">= 0.0.2"
 gem "ruboty-alias", "= 0.0.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,16 +9,6 @@ GIT
       ruboty
 
 GIT
-  remote: https://github.com/atm-snag2/ruboty-slack_rtm.git
-  revision: 821035500115acc02a52711d7c386fdbc447488e
-  branch: use-slack-ruby-client
-  specs:
-    ruboty-slack_rtm (3.2.5)
-      ruboty (>= 1.1.4)
-      slack-ruby-client (~> 2.0)
-      websocket-client-simple (>= 0.5.0)
-
-GIT
   remote: https://github.com/increments/ruboty-response.git
   revision: 2255896972ddc9e1e549333b74e9a5724a7decdf
   specs:
@@ -40,31 +30,62 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    async (2.23.1)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.9)
+      metrics (~> 0.12)
+      traces (~> 0.15)
+    async-http (0.88.0)
+      async (>= 2.10.2)
+      async-pool (~> 0.9)
+      io-endpoint (~> 0.14)
+      io-stream (~> 0.6)
+      metrics (~> 0.12)
+      protocol-http (~> 0.49)
+      protocol-http1 (~> 0.30)
+      protocol-http2 (~> 0.22)
+      traces (~> 0.10)
+    async-pool (0.10.3)
+      async (>= 1.25)
+    async-websocket (0.30.0)
+      async-http (~> 0.76)
+      protocol-http (~> 0.34)
+      protocol-rack (~> 0.7)
+      protocol-websocket (~> 0.17)
     base64 (0.2.0)
     bigdecimal (3.1.8)
     chrono (0.6.0)
       activesupport (>= 5.2)
     concurrent-ruby (1.3.1)
     connection_pool (2.4.1)
+    console (1.30.2)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     csv (3.3.3)
     dotenv (3.1.2)
     drb (2.2.1)
-    event_emitter (0.2.6)
     faraday (2.12.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-mashify (0.1.1)
+    faraday-mashify (1.0.0)
       faraday (~> 2.0)
       hashie
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
+    faraday-multipart (1.1.0)
+      multipart-post (~> 2.0)
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     faraday-retry (2.3.0)
       faraday (~> 2.0)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.0)
     fiddle (1.1.6)
-    gli (2.21.1)
+    gli (2.22.2)
+      ostruct
     hashie (5.0.0)
     holiday_japan (1.4.4)
     httparty (0.21.0)
@@ -75,13 +96,17 @@ GEM
     increments-schedule (0.18.0)
       holiday_japan (~> 1.1)
     io-console (0.8.0)
+    io-endpoint (0.15.2)
+    io-event (1.10.0)
+    io-stream (0.6.1)
     json (2.10.2)
     logger (1.7.0)
     mem (0.1.5)
+    metrics (0.12.2)
     mini_mime (1.1.5)
     minitest (5.23.1)
     multi_xml (0.6.0)
-    multipart-post (2.4.0)
+    multipart-post (2.4.1)
     mutex_m (0.2.0)
     net-http (0.6.0)
       uri
@@ -90,6 +115,18 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     ostruct (0.6.1)
+    protocol-hpack (1.5.1)
+    protocol-http (0.49.0)
+    protocol-http1 (0.34.0)
+      protocol-http (~> 0.22)
+    protocol-http2 (0.22.1)
+      protocol-hpack (~> 1.4)
+      protocol-http (~> 0.47)
+    protocol-rack (0.11.2)
+      protocol-http (~> 0.43)
+      rack (>= 1.0)
+    protocol-websocket (0.20.1)
+      protocol-http (~> 0.2)
     public_suffix (5.0.4)
     qiita (1.5.0)
       activesupport
@@ -144,25 +181,27 @@ GEM
       ruboty (~> 1.0)
     ruboty-scorekeeper (1.0.0)
       ruboty
+    ruboty-slack_events (0.1.1)
+      async-websocket (~> 0.25)
+      ruboty (>= 1.1.4)
+      slack-ruby-client (~> 2.5)
     ruby-openai (3.5.0)
       httparty (>= 0.18.1)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    slack-ruby-client (2.3.0)
+    slack-ruby-client (2.5.2)
       faraday (>= 2.0)
       faraday-mashify
       faraday-multipart
       gli
       hashie
+      logger
     slop (3.6.0)
+    traces (0.15.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uri (1.0.3)
-    websocket (1.2.10)
-    websocket-client-simple (0.8.0)
-      event_emitter
-      websocket
 
 PLATFORMS
   ruby
@@ -188,7 +227,7 @@ DEPENDENCIES
   ruboty-ruby (>= 0.0.2)
   ruboty-ruby_persistence (= 0.2.0)
   ruboty-scorekeeper
-  ruboty-slack_rtm!
+  ruboty-slack_events
 
 RUBY VERSION
    ruby 3.4.1p100


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->

> [!IMPORTANT]
> Before you merge this, you have to configure Slack App with Events API.
> See: https://github.com/tomoasleep/ruboty-slack_events 

This PR uses https://github.com/tomoasleep/ruboty-slack_events to use [Slack Events API](https://api.slack.com/apis/events-api) instead of Legacy [Real Time Messaging API](https://api.slack.com/legacy/rtm).