### PR TITLE
Update ruboty-slack_events to 0.2.0 (from 0.1.1)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
       ruboty (~> 1.0)
     ruboty-scorekeeper (1.0.0)
       ruboty
-    ruboty-slack_events (0.1.1)
+    ruboty-slack_events (0.2.0)
       async-websocket (~> 0.25)
       ruboty (>= 1.1.4)
       slack-ruby-client (~> 2.5)


### PR DESCRIPTION
This PR updates ruboty-slack_events to 0.2.0 (from 0.1.1).

## changes

See: http://github.com/tomoasleep/ruboty-slack_events/compare/v0.1.1...v0.2.0

