### PR TITLE
Update ruboty-slack_events to 0.3.0 (from 0.2.0)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
       ruboty (~> 1.0)
     ruboty-scorekeeper (1.0.0)
       ruboty
-    ruboty-slack_events (0.2.0)
+    ruboty-slack_events (0.3.0)
       async-websocket (~> 0.25)
       ruboty (>= 1.1.4)
       slack-ruby-client (~> 2.5)


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->

This PR updates ruboty-slack_events to 0.3.0 (from 0.2.0)

## Changes

Ref: https://github.com/tomoasleep/ruboty-slack_events/compare/v0.2.0...v0.3.0